### PR TITLE
Acc library bugfix concerning multiple screen setups

### DIFF
--- a/lib/Acc.ahk
+++ b/lib/Acc.ahk
@@ -878,7 +878,7 @@ class Acc {
         if !(IsSet(x) && IsSet(y)) {
             DllCall("GetCursorPos", "int64P", &pt64:=0), x := 0xFFFFFFFF & pt64, y := pt64 >> 32
         } else {
-            pt64 := y << 32 | x
+            pt64 := y << 32 | (x & 0xFFFFFFFF)
         }
         wId := DllCall("GetAncestor", "UInt", DllCall("user32.dll\WindowFromPoint", "int64",  pt64), "UInt", GA_ROOT := 2) ; hwnd from point by SKAN
         if activateChromium
@@ -1012,7 +1012,7 @@ class Acc {
     }
 
 	static WindowFromPoint(X, Y) { ; by SKAN and Linear Spoon
-		return DllCall("GetAncestor", "UInt", DllCall("user32.dll\WindowFromPoint", "Int64", Y << 32 | X), "UInt", 2)
+		return DllCall("GetAncestor", "UInt", DllCall("user32.dll\WindowFromPoint", "Int64", Y << 32 | (X & 0xFFFFFFFF)), "UInt", 2)
 	}
 
     class Viewer {


### PR DESCRIPTION
Acc.ObjectFromPoint and Acc.WindowFromPoint use the Win32 function WindowFromPoint, which accepts a 64-bit POINT integer as the only argument. Apparently when trying to call it with a negative X coordinate, the X-coordinate needs to be bit-masked or otherwise the function returns 0. This pull request does that by changing lines containing `Y << 32 | X` with `Y << 32 | (X & 0xFFFFFFFF)`. 
Although I am unable to properly test this in a multi-monitor setup where the bug can occur, user [Xeo786](https://www.autohotkey.com/boards/memberlist.php?mode=viewprofile&u=65131) confirms in a private message that this change fixes the bug.